### PR TITLE
docs: fix `What does a cell contain?`

### DIFF
--- a/src/content/courses/basic-theory/chapter_1.mdx
+++ b/src/content/courses/basic-theory/chapter_1.mdx
@@ -19,5 +19,5 @@ other cells and run on-chain through the `CKB` virtual machine, `CKB-VM`.
 
 As simple as that, this is the so-called `smart contract` on CKB.
 
-## References
+## Reference
 - [Nervos Network glossary](https://docs.nervos.org/docs/basics/glossary#general-glossary) covers a range of topics including blockchain, smart contracts, decentralisation, and more. You could do a quick search when you need it, no need to put all of them into your mind now.

--- a/src/content/courses/basic-theory/chapter_2.mdx
+++ b/src/content/courses/basic-theory/chapter_2.mdx
@@ -1,20 +1,20 @@
 import Example from '~/content/courses/basic-theory/chapter_2_example.tsx';
 
-# How to own a cell?
+# What does a cell contain?
 
 Cells are obtained by the verification of the global consensus on the chain. Owning cells entails costs, since their storage space is limited.
 
 This leads us to the function of CKB's native tokens.
 
-Imagine a cell as a small box that can carry objects. The box itself is created by tokens. A box's size is determined by how many tokens you have.
+Imagine a cell as a small box that can carry objects. The box itself is created by tokens. A box's size is determined by how many tokens the box has.
 
 A box (cell) can also be divided into multiple boxes, as long as the total space of the boxes is equal to the number of tokens you have.
 
 In Nervos CKB, 1 CKB is equal to 1 byte of storage space.
 
-For example, if you have 100 CKBs, you will have 100 bytes of on-chain space, so you can create a box with 100 bytes of space. You can divide that 100 bytes into as many boxes as you like.
+For example, if you have 100 CKBs, you will have 100 bytes of on-chain space, so you can create a box with 100 bytes of space.
 
-The box can store data. The data size must be smaller than the space of the box, because the box includes other components which also occupy some space.
+The box can store data. The data size must be smaller than the space of the box, because the box contains other components which also occupy some space.
 
 For instance, one Chinese character accounts for 2 bytes (GBK encoding). If you have 100 CKBs in a cell, you can probably save less than 50 Chinese characters in it.
 
@@ -22,13 +22,11 @@ In the case of Dream of the Red Chamber, this novel is approximately 780,000 wor
 
 As you can see, on-chain storage is a precious asset.
 
-CKB stores consensus data on-chain, enabling everyone to upload data valuable and necessary to consensus. It is comparable to a knowledge base owned by all of humanity.
+CKB stores consensus data on-chain, enabling anyone to upload valuable and necessary data to the consensus. It is comparable to a knowledge base owned by all of humanity.
 
-This is how CKB got its name (Common Knowledge Base).
+This is how CKB got its name, `Common Knowledge Base`.
 
-<br />
-
-### The entire cell data structure looks like this:
+## The entire cell data structure looks like this:
 
 ```ts
 Cell: {
@@ -39,33 +37,28 @@ Cell: {
 }
 ```
 
-#### The four fields are defined as follows:
+### The four fields are defined as follows:
 
 - `capacity`: the space size of the cell, i.e. the integer number of native tokens represented by this cell, usually expressed in hexadecimal. The basic unit for capacity is shannon, 1 CKB equals 10\*\*8 shannon.
 - `lock`: a script, which is essentially the equivalent of a lock. We'll show you more details later.
 - `type`: a script, same as the lock but for a different purpose.
-- `data`: an unformatted string where any type of data can be stored.
+- `data`: this field can store arbitrary bytes, which means any type of data
 
 > More detailed descriptions of data structures can be found here: [Cell data structure](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0019-data-structures/0019-data-structures.md#Cell)
 
-Note：A cell's total size for all four fields above must be less than or equal to the capacity of the cell.
-
-As shown below
+**Note**：A cell's total size for all four fields above must be less than or equal to the capacity of the cell. As shown below
 
 ```
-Cell's total space occupied = capacity
-                            >= Sum of the 4 fields' length
+capacity  = Cell's total space
+         >= Sum of the 4 fields' byte length
 ```
 
-To better understand, let's look at the following example.
+## Example
 
-Type in something as the cell data to see the real-time changes in the length of the cell. Click on the cell to view the cell content and the actual length of each field.
+To get a better understanding of this, let's look at the following example.
 
-The capacity of the cell is set as 0x1dcd65000, which is 80 bytes in size. If the change in data causes the actual occupancy to grow beyond the value of capacity, the cell will be considered invalid.
+Type something as the cell data to see the real-time changes in the length of the cell. Click on the cell to view the cell content and the actual length of each field.
 
-### Example
-
-<br />
+The capacity of the cell is set to 0x1dcd65000 (8,000,000,000 shannons = 80 CKBs), which is 80 bytes in size. If the change in data causes the actual occupancy to exceed the capacity value, the cell will be considered invalid.
 
 <Example />
-<br />

--- a/src/content/courses/basic-theory/chapter_2_example.tsx
+++ b/src/content/courses/basic-theory/chapter_2_example.tsx
@@ -15,9 +15,9 @@ const Example: Component = () => {
     cellOutput: {
       capacity: '0x1dcd65000',
       lock: {
-        args: '0x36c329ed630d6ce750712a477543672adab57f4c',
         codeHash: '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8',
         hashType: 'type',
+        args: '0x36c329ed630d6ce750712a477543672adab57f4c',
       },
     },
     data: '0x',
@@ -57,9 +57,9 @@ const Example: Component = () => {
     return {
       capacity: '8 Bytes',
       lock: {
-        args: b2.toString() + ' Bytes',
         code_hash: '32 Bytes',
         hash_type: '1 Bytes',
+        args: b2.toString() + ' Bytes',
       },
       data: b5.toString() + ' Bytes',
     };
@@ -71,7 +71,7 @@ const Example: Component = () => {
 
   const isCapacityEnough = createMemo(() => {
     return (
-      shannon2CKB(BI.from(cell().cellOutput.capacity).toString(10)) >
+      shannon2CKB(BI.from(cell().cellOutput.capacity).toString(10)) >=
       BI.from(dataTotalLength()).toHexString()
     );
   });
@@ -121,14 +121,14 @@ const Example: Component = () => {
         </i>
         <div class="px-4">
           <span class="text-sm font-medium">Capacity</span>
-          <p class="text-xs">{cell().cellOutput.capacity} ( shannon ) = 80 ( CKB )</p>
+          <p class="text-xs">{cell().cellOutput.capacity} (shannon) = 80 (CKB)</p>
         </div>
         <i class="text-5xl py-2 px-1">
           {isCapacityEnough() ? <BiRegularChevronRight /> : <BiRegularChevronLeft />}
         </i>
         <div class="px-4">
           <span class="text-sm font-medium">Actual occupancy</span>
-          <p class="text-xs">{dataTotalLength()} ( CKB )</p>
+          <p class="text-xs">{dataTotalLength()} (CKB)</p>
         </div>
       </div>
       <Dialog footer={null} title={null} context={dialog}>

--- a/src/content/courses/basic-theory/index.ts
+++ b/src/content/courses/basic-theory/index.ts
@@ -24,7 +24,7 @@ const basicTheory: Course = {
     },
     {
       id: 'chapter_2',
-      title: 'How to own a cell?',
+      title: 'What does a cell contain?',
       article: () => import('./chapter_2.mdx'),
     },
     {


### PR DESCRIPTION
## Changes
1. can't divide that 100 bytes into too many boxes/cells
2. fix example.tsx: capacity should >= Sum of the 4 fields' byte length
3. fix some small wording