### PR TITLE
Fix the interpretations of `code_hash`

### DIFF
--- a/src/content/courses/basic-theory/chapter_5.mdx
+++ b/src/content/courses/basic-theory/chapter_5.mdx
@@ -2,7 +2,7 @@
 
 We have learned that the lock and type fields of the cell are used to lock the box and to guarantee its ownership and control.
 
-Lock is a script structure that looks like this:
+A script‘s structure looks like this:
 
 ```ts
 Script: {
@@ -19,19 +19,43 @@ The answer is simple: the code is stored in another cell!
 We know that the data field of a cell can contain arbitrary data, so we can put the real code in the data field of another cell and implement this cell as a dependency to a transaction. This dependency cell is called `CellDep` (dep cell).
 
 Depending on the value of `hash_type`, `code_hash` has different interpretations:
-- If hash_type is "data" or "data1", code_hash should match the blake2b hash of data in a dep cell;
-- If hash_type is "type", code_hash should instead match the type script hash of a dep cell.
+- If hash_type is "data" or "data1", code_hash should match [blake2b_ckbhash](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0022-transaction-structure/0022-transaction-structure.md#appendix-a-compute-various-hash)(data) of a dep cell;
+- If hash_type is "type", code_hash should instead match [blake2b_ckbhash](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0022-transaction-structure/0022-transaction-structure.md#appendix-a-compute-various-hash)(type script) of a dep cell.
 
-When unlocking a cell, we simply import the dep cell, and CKB will follow the above rules to find the corresponding code.
+## The code locating workflow
+
+Please keep in mind that the `code_hash` and `hash_type` fields are used to locate the code. When unlocking a cell, a transaction simply imports the dep cell, and CKB will follow the rules above to find and execute the corresponding code.
+
+#### When hash_type is "data" or "data1"
+![code-locating-via-data-hash](https://raw.githubusercontent.com/nervosnetwork/rfcs/master/rfcs/0022-transaction-structure/code-locating.png)
+
+#### When hash_type is "type" 
+![code-locating-via-type-hash](https://raw.githubusercontent.com/nervosnetwork/rfcs/master/rfcs/0022-transaction-structure/code-locating-via-type.png)
 
 So why not just put in the real code, but use this indexing approach?
 
 One of the major advantages of this design is that if everyone needs the same type of lock, the lock code will be identical, and so will the code_hash value. Then it is just a matter of introducing the same dep cell rather than deploying the same code all over again for each case.
 
-Here's a real example.
+## Here's a real example
 
-CKB has an important built-in smart contract called [SECP256K1_BLAKE160](https://pudge.explorer.nervos.org/scripts#secp256k1_blake160). It is the common lock used by many cells in regular transfer transactions. A cell using this lock is protected by the SECP256K1 encryption algorithm.
+[Simple User Defined Token (Simple UDT or SUDT)](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0025-simple-udt/0025-simple-udt.md) provides a way for dapp developers to issue custom tokens on Nervos CKB. It's a widely used type script.
 
-To achieve this, CKB created several cells in the genesis block and then put the specific code of the SECP256K1 encryption algorithm into the data field of [these cells](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0024-ckb-genesis-script-list/0024-ckb-genesis-script-list.md#secp256k1blake160). During the transaction, these cells are introduced as dep cells. Then we fill in the code_hash with the hash of the dep cell's type script while putting our public key hash in the args field, so the lock can determine whether the signature attached to a transfer transaction is authentic and valid.
+Let's try to find the real code of SUDT type script on CKB testnet:
+
+| parameter   | value                                                                |
+| ----------- | -------------------------------------------------------------------- |
+|  code_hash  | `0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4` |
+|  hash_type  | `type`                                                               |
+|  tx_hash    | [0xe12877ebd2c3c364dc46c5c992bcfaf4fee33fa13eebdf82c591fc9825aab769](https://pudge.explorer.nervos.org/transaction/0xe12877ebd2c3c364dc46c5c992bcfaf4fee33fa13eebdf82c591fc9825aab769) |
+|  index      | `0x0`                                                                |
+|  dep_type   | `code`                                                               |
+
+1. Click the [link](https://pudge.explorer.nervos.org/transaction/0xe12877ebd2c3c364dc46c5c992bcfaf4fee33fa13eebdf82c591fc9825aab769) of tx_hash and jump to the transaction view of CKB testnet explorer;
+2. Click the `Cell Info` button of `#0 Output`.
+
+![the real code of SUDT type script](https://user-images.githubusercontent.com/1297478/228566683-18de0113-3bcd-4ab6-8000-0ab385e7a8e6.png)
+> Look! You found it!
+
+That is to say, if a cell's type script code_hash is set to `0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4`, then that cell will follow the logic of the above code bytes compiled from [simple_udt.c](https://github.com/nervosnetwork/ckb-production-scripts/blob/e570c11aff3eca12a47237c21598429088c610d5/c/simple_udt.c).
 
 But at this point, another question may come to your mind.

--- a/src/content/courses/basic-theory/chapter_5.mdx
+++ b/src/content/courses/basic-theory/chapter_5.mdx
@@ -8,26 +8,30 @@ Lock is a script structure that looks like this:
 Script: {
   code_hash: HexString
   args: HexString
-  hash_type: either 'data' or 'type'
+  hash_type: Uint8, there are three allowed values: {0: "data", 1: "type", 2: "data1"}
 }
 ```
 
-You may notice that the code_hash is not the actual code but a hash of the code, equivalent to an index of the code. This index allows us to retrieve the code. So, where is the code anyway?
+You may notice that the `code_hash` is not the actual code, but some kind of index of the code. This index allows us to retrieve the code. So, where is the code anyway?
 
-The answer is simple: code is in another cell!
+The answer is simple: the code is stored in another cell!
 
-We know that the data field of the cell can contain arbitrary data, so we can put the real code in the data field of another cell and implement this cell as a dependency to a transaction. This dependency cell is called “dep cell”.
+We know that the data field of a cell can contain arbitrary data, so we can put the real code in the data field of another cell and implement this cell as a dependency to a transaction. This dependency cell is called `CellDep` (dep cell).
 
-When unlocking a cell, we simply import the dep cell, and CKB will match the hash of the data in the dep cell with code_hash to find the corresponding code.
+Depending on the value of `hash_type`, `code_hash` has different interpretations:
+- If hash_type is "data" or "data1", code_hash should match the blake2b hash of data in a dep cell;
+- If hash_type is "type", code_hash should instead match the type script hash of a dep cell.
+
+When unlocking a cell, we simply import the dep cell, and CKB will follow the above rules to find the corresponding code.
 
 So why not just put in the real code, but use this indexing approach?
 
-One of the major advantages of this design is that if everyone needs the same type of lock, the lock code will be identical, the code_hash value will be identical, too. Then it is just a matter of introducing the same dep cell rather than deploying the same code all over again for each case.
+One of the major advantages of this design is that if everyone needs the same type of lock, the lock code will be identical, and so will the code_hash value. Then it is just a matter of introducing the same dep cell rather than deploying the same code all over again for each case.
 
 Here's a real example.
 
-CKB has an important built-in smart contract called SECP256K1_BLAKE160. It is the default lock used by each cell in the lock field in regular transfer transactions. This lock means the SECP256K1 encryption algorithm protects the ownership of each cell.
+CKB has an important built-in smart contract called [SECP256K1_BLAKE160](https://pudge.explorer.nervos.org/scripts#secp256k1_blake160). It is the common lock used by many cells in regular transfer transactions. A cell using this lock is protected by the SECP256K1 encryption algorithm.
 
-To achieve this, CKB created several cells in the genesis block and then put the specific code of the SECP256K1 encryption algorithm into the data field of these cells. During the transaction, these cells are introduced as dep cells. Then we fill in the code_hash with the hash of the dep cell's data field while putting our public key hash in the args field, so the lock can determine whether the signature attached to a transfer transaction is authentic and valid.
+To achieve this, CKB created several cells in the genesis block and then put the specific code of the SECP256K1 encryption algorithm into the data field of [these cells](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0024-ckb-genesis-script-list/0024-ckb-genesis-script-list.md#secp256k1blake160). During the transaction, these cells are introduced as dep cells. Then we fill in the code_hash with the hash of the dep cell's type script while putting our public key hash in the args field, so the lock can determine whether the signature attached to a transfer transaction is authentic and valid.
 
 But at this point, another question may come to your mind.

--- a/src/content/courses/basic-theory/chapter_9.mdx
+++ b/src/content/courses/basic-theory/chapter_9.mdx
@@ -1,4 +1,4 @@
-# Summary
+# Summary 2
 
 Congratulations! Now you are prepared for the tutorial!
 


### PR DESCRIPTION
Depending on the value of `hash_type`, `code_hash` has different interpretations