### PR TITLE
Fix difference between lock and type script

### DIFF
--- a/src/content/courses/basic-theory/chapter_6.mdx
+++ b/src/content/courses/basic-theory/chapter_6.mdx
@@ -1,23 +1,24 @@
 # What if the lock code is lost?
 
-The code of lock is kept in another cell. What if someone destroys that cell? When this cell is spent, the dep cell becomes dead, and the code of lock will be gone. Does this mean that the cell that uses this lock can no longer unlock it?
+So, we know that a lock's code is usually kept in another cell.
+What happens if someone destroys that cell? If that cell is spent, the dep cell of a transaction becomes dead, and the lock's code will be gone.
+Does this mean that the cell using that lock can no longer be unlocked?
 
-Theoretically, this is true. Technically, the cell that contains the code of the lock should last as long as the chain does, and no one can access this cell. So, if you look it up, you can see that the dep cells that all the built-in lock scripts of CKB have been built on are inherently inaccessible by anyone. Because we have set the value 0x0000... in the lock field of each dep cell (i.e. the lock of the cell itself where to put the lock code), which means that no one will ever be able to unlock these cells again, and the code will always be there:
+Theoretically, this is true.
+Technically, the cell that contains the code of a lock should last as long as the chain, and no one can access this cell.
 
+For [CKB's built-in scripts](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0024-ckb-genesis-script-list/0024-ckb-genesis-script-list.md), things are simple. Because the cells containing the code of all CKB's built-in lock scripts are inherently inaccessible by anyone.
+
+The lock field of each built-in script code cell is 
 ```ts
-SECP256K1's lock: {
-                code_hash: 0x0000000000000000000000000000000000000000000000000000000000000000
-                hash_type: data
-                args: 0x
+Never unlockable lock: {
+  code_hash: 0x0000000000000000000000000000000000000000000000000000000000000000
+  hash_type: data
+  args: 0x
 }
 ```
+which means that no one will ever be able to unlock it, and the code will always be there.
 
-We can still unlock our own cell if the dep cell was destroyed, because you can just redeploy the same lock code to a new cell and then bring in the new cell as a dep cell so that you can retrieve the lock code. Because the code remains identical, the hash of the code stays the same, and the value of code_hash also remains the same. This is the additional flexibility of CKB.
+For other scripts, we can still unlock our own cell if the dep cell was destroyed,
+because actually we can just redeploy the same lock code to a new cell and then reference the new cell as a dep cell so that you can retrieve the lock code. 
 
-These examples of locks that we've talked about are the locks in the lock field of the cell.
-
-In addition to the default lock, lock script, a cell can also have an optional lock, type script. These two locks are fundamentally the same, but they are given different names because of their different uses.
-
-The lock script is usually used to protect the ownership of the box, while the type script is used to ensure that the cell follows certain data transformation rules during the transaction.
-
-To understand this, we must start by understanding what a transaction in CKB is all about.

--- a/src/content/courses/basic-theory/chapter_8.mdx
+++ b/src/content/courses/basic-theory/chapter_8.mdx
@@ -1,16 +1,31 @@
-# Role of the type script
+# Difference between lock and type script
+
+Every cell has a lock script. The lock script must run when the cell is used as an input in a transaction.
+In addition to the lock script, a cell can also have an optional lock, type script.
+
+These two locks are fundamentally the same, but they are given different names because of their different uses.
+
+**The lock script is usually used to protect the ownership of the box, indicating who can unlock the box,
+while the type script is used to ensure that the cell follows certain application logic.**
 
 As cells are transformed from inputs to outputs in a transaction, certain user-defined rules can guide the transformation process.
 
-For example, I want a cell to produce only one new cell at a time in a transaction, I can make such a rule into a lock on the box.
+For example, I want a cell to produce only one new cell at a time in a transaction, I can program such a rule into a type lock of the box.
 
-Another example, I would like a cell to never show the word “carrot” in its data field during a transaction, I could create a lock with such a rule, which would be added as a type lock to the box.
+Another example, I would like a cell to never show the word "carrot" in its data field during a transaction, I could also create a type lock with such a rule.
 
-This is the distinction between the type script and the lock script. The former protects the ownership of the box and the latter secures the data transformation rules. The lock lock is the gatekeeper, while the type lock is the guardian.
+This is the distinction between the type script and the lock script. 
+The former protects the ownership of the box and the latter secures the cell transformation rules.
 
-This variance in use comes down to the difference in the design of the two locks in terms of their execution mechanism which can be specified as follows:
+**The lock script is the gatekeeper, while the type script is the guardian.**
 
-- `Lock script` In a transaction, the lock scripts of all inputs will be executed once.
-- `Type script` In a transaction, the type scripts of all inputs and outputs will be executed once.
+This variance in use comes down to the difference in the design of the two locks in terms of their execution mechanism:
 
-Due to the variations in execution mechanisms, derived usage also varies. You are free to have your own opinions on this, but essentially these are the recommended official usages.
+- `Lock script`: In a transaction, the lock scripts run for all inputs by group.
+- `Type script`: In a transaction, the type scripts run for all inputs and outputs by group.
+
+**Note**: CKB does not run the script one by one. It first groups the inputs or outputs by script and runs the same script only once.
+
+Due to the variations in execution mechanisms, different suitable uses are derived.
+Essentially these are just the recommended official usages.
+Of course, you are perfectly free to have your own ideas.


### PR DESCRIPTION
## Changes
- [Fix some wording in basic-theory/chapter_6.mdx](https://github.com/Flouse/ckb-academy/commit/ec1f6fd65d06c8cd37f503e0a4be7af92d281d8f)
- move some content from chapter_6 to chapter_8
- [Fix Difference between lock and type script](https://github.com/Flouse/ckb-academy/commit/d11d2d3dada16e96b8e07c68a0a1ec86086e9ac6)
   **Note**: CKB does not run the script one by one. It first groups the inputs or outputs by script and runs the same script only once.

## Preview Link
https://ckbacademy-git-first-lesson-flouse.vercel.app/courses/basic-theory
