### PR TITLE
Update readm eand start dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ yarn
 yarn run prepare
 
 # start a development server: https://start.solidjs.com/api/dev
-yarn dev
+yarn dev:site
 # or
 turbo run dev
 ```

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -17,4 +17,7 @@ export default defineConfig({
   ssr: {
     external: ['monaco-editor'],
   },
+  server: {
+    open: process.env.NODE_ENV === 'development',
+  },
 });

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -17,4 +17,7 @@ export default defineConfig({
   ssr: {
     external: ['monaco-editor'],
   },
+  server: {
+    open: true,
+  },
 });

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -17,7 +17,4 @@ export default defineConfig({
   ssr: {
     external: ['monaco-editor'],
   },
-  server: {
-    open: true,
-  },
 });


### PR DESCRIPTION
Based on the error of this PR https://github.com/Flouse/ckb-academy/pull/46, it seems that Vercel is timing out due to its inability to open a browser. I have added a condition to the auto-open feature, which will only trigger in development mode, and should prevent this issue from occurring.

- fix #45 