### PR TITLE
Add guild for how to use Hex to Decimal

### DIFF
--- a/site/src/content/courses/basic-theory/chapter_2.mdx
+++ b/site/src/content/courses/basic-theory/chapter_2.mdx
@@ -1,4 +1,5 @@
 import Example from '~/content/courses/basic-theory/chapter_2_example.tsx';
+import Guild from '~/content/courses/basic-theory/chapter_2_guild.tsx';
 
 # What does a cell contain?
 
@@ -56,6 +57,10 @@ capacity  = Cell's total space
 ## Example
 
 To get a better understanding of this, let's look at the following example.
+
+First, let's familiarize ourselves with the calculation of capacity. Try using the `Hex to Decimal` calculator in the Toolbox on the right. Now let's calculate the decimal equivalent of `0x12a05f200` and enter it into the input box below.
+
+<Guild />
 
 Type something as the cell data to see the real-time changes in the length of the cell. Click on the cell to view the cell content and the actual length of each field.
 

--- a/site/src/content/courses/basic-theory/chapter_2_guild.tsx
+++ b/site/src/content/courses/basic-theory/chapter_2_guild.tsx
@@ -1,0 +1,52 @@
+import { Component, createSignal } from 'solid-js';
+import { BI } from '@ckb-lumos/bi';
+
+const Example: Component = () => {
+  const [inputValue, setInputValue] = createSignal<string>('');
+  const [isValid, setIsValid] = createSignal<boolean>(false);
+
+  const handleInputChange = (e: Event) => {
+    const newValue = (e.target as HTMLInputElement).value.trim();
+    setInputValue(newValue);
+    const num = BI.from(newValue);
+    setIsValid(num.eq(BI.from('5000000000')));
+  };
+
+  const getValidityMessage = (): string => {
+    if (isValid()) {
+      return 'Correct!';
+    } else if (inputValue() === '') {
+      return '';
+    } else {
+      return 'The value calculator is incorrect';
+    }
+  };
+
+  const getValidityColor = (): string => {
+    if (isValid()) {
+      return 'text-success border-success';
+    } else if (inputValue() === '') {
+      return '';
+    } else {
+      return 'text-error border-error';
+    }
+  };
+
+  return (
+    <div class="not-prose">
+      <div class="flex flex-col items-center justify-center mb-6">
+        <input
+          onInput={handleInputChange}
+          class={`input mb-4 font-medium ${getValidityColor()}`}
+          placeholder="Input the Decimal of Hex 0x12a05f200"
+          value={inputValue()}
+        />
+        <div class={`${isValid() ? 'text-success' : 'text-error'} font-medium text-sm`}>
+          {getValidityMessage()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Example;

--- a/site/src/content/courses/basic-theory/chapter_2_guild.tsx
+++ b/site/src/content/courses/basic-theory/chapter_2_guild.tsx
@@ -1,15 +1,19 @@
 import { Component, createSignal } from 'solid-js';
 import { BI } from '@ckb-lumos/bi';
 
-const Example: Component = () => {
+const Guild: Component = () => {
   const [inputValue, setInputValue] = createSignal<string>('');
   const [isValid, setIsValid] = createSignal<boolean>(false);
 
   const handleInputChange = (e: Event) => {
     const newValue = (e.target as HTMLInputElement).value.trim();
     setInputValue(newValue);
-    const num = BI.from(newValue);
-    setIsValid(num.eq(BI.from('5000000000')));
+    if (/^\d+$/.test(newValue)) {
+      const num = BI.from(newValue);
+      setIsValid(num.eq(BI.from('5000000000')));
+    } else {
+      setIsValid(false);
+    }
   };
 
   const getValidityMessage = (): string => {
@@ -49,4 +53,4 @@ const Example: Component = () => {
   );
 };
 
-export default Example;
+export default Guild;


### PR DESCRIPTION
> - In the CKB basic practical operation, the transaction fee is set to 0 in the first two steps when building a transaction JSON, but it is required in the final step. This may be confusing for beginners and result in errors.
>    - A calculator application process (e.g., for calculating capacity) should be added to the process flow to show users how to use and when to use Hex To Decimal.
>     - Several hints should be added to guide users on obtaining txhash from live cells and filling in the txHash field in the JSON structure from chainInfo. 

- https://github.com/Flouse/ckb-academy/issues/44


![image](https://github.com/Flouse/ckb-academy/assets/11926244/76de8f1d-584c-40b2-9c54-f6615688e20c)

If we use this approach, it will not only help beginners to use Hex to Decimal, but also draw their attention to the four tools on the right side.
