### PR TITLE
fix: add vercel.json to site/ for SPA routing

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,23 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "credentialless"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
Direct visits to client-side routes like `/courses` return a 404, while navigation from the home page works fine. This is a classic SPA routing issue.

## Root Cause
The project was refactored into a monorepo with the application code living in the `site/` directory. The existing `vercel.json` (with SPA fallback rewrites) is at the repository root, but Vercel reads configuration from the deployment root directory. If the deployment is configured to use `site/` as the root directory, the root `vercel.json` is ignored and deep links 404.

## Fix
Add a copy of `vercel.json` into the `site/` directory so Vercel picks up the rewrite rules regardless of how the project root is configured in the dashboard.

## Changes
- Added `site/vercel.json` with SPA rewrite rules (`/(.*)` → `/index.html`) and the required COOP/COEP headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)