### PR TITLE
fix: copy vercel.json into site/public for build output

### DIFF
--- a/site/public/vercel.json
+++ b/site/public/vercel.json
@@ -1,0 +1,23 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "credentialless"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
The previous fix (#126) added `vercel.json` to `site/`, but direct visits to `/courses` still return 404.

## Root Cause
Vercel may be deploying from the build output directory (`dist/public/`) rather than the source directory. In that case, `vercel.json` needs to be inside the build output to be picked up.

## Fix
Copy `vercel.json` into `site/public/`. The `solid-start` build process copies files from `public/` into `dist/public/`, so `vercel.json` will end up in the deployed artifacts and Vercel will apply the SPA rewrite rules.

## Changes
- Added `site/public/vercel.json` with SPA rewrite rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)